### PR TITLE
Add renovate-config preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
+    "github>lewtec/renovate-config:base",
     "config:recommended"
   ],
   "nix": {


### PR DESCRIPTION
This PR adds the renovate-config preset to the repository's Renovate configuration.

The preset includes best practices and recommended configurations for dependency updates.

Changes:
- Added `extends` configuration to include `github>lewtec/renovate-config:base`
