### PR TITLE
🛟 Arrumador: Configure tooling and CI

### DIFF
--- a/.github/workflows/autorelease.yml
+++ b/.github/workflows/autorelease.yml
@@ -1,0 +1,60 @@
+name: autorelease
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - '*'
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  autorelease:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: jdx/mise-action@v2
+        with:
+          experimental: true
+
+      - name: Install
+        run: mise run install
+
+      - name: Codegen
+        run: mise run codegen
+
+      - name: PR if Difference
+        id: cpr
+        uses: peter-evans/create-pull-request@v6
+        with:
+          title: "chore: update codegen"
+          commit-message: "chore: update codegen"
+          branch: "chore/update-codegen"
+          delete-branch: true
+
+      - name: Stop if PR created
+        if: steps.cpr.outputs.pull-request-number != ''
+        run: exit 1
+
+      - name: CI
+        run: mise run ci
+
+      - name: Release (Conditional)
+        if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/')
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create ${{ github.ref_name }} --generate-notes || true
+
+      - name: Artifacts (Conditional)
+        if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/')
+        uses: actions/upload-artifact@v4
+        with:
+          name: artifacts
+          path: .

--- a/.github/workflows/autorelease.yml
+++ b/.github/workflows/autorelease.yml
@@ -37,6 +37,7 @@ jobs:
           commit-message: "chore: update codegen"
           branch: "chore/update-codegen"
           delete-branch: true
+          base: ${{ github.head_ref || github.ref_name }}
 
       - name: Stop if PR created
         if: steps.cpr.outputs.pull-request-number != ''

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,45 @@
+[tools]
+"github:lucasew/workspaced" = "0.2.1"
+
+[tasks.lint]
+run = "workspaced codebase lint"
+
+[tasks.fmt]
+run = "workspaced codebase format"
+
+[tasks.test]
+depends = ["test:*"]
+
+[tasks."test:noop"]
+run = "true"
+
+[tasks.codegen]
+depends = ["codegen:*"]
+
+[tasks."codegen:noop"]
+run = "true"
+
+[tasks.install]
+depends = ["install:*"]
+
+[tasks."install:detect"]
+run = """
+if [ -f "package-lock.json" ]; then
+    npm ci
+elif [ -f "yarn.lock" ]; then
+    yarn install --frozen-lockfile
+elif [ -f "pnpm-lock.yaml" ]; then
+    pnpm install --frozen-lockfile
+elif [ -f "Cargo.lock" ]; then
+    cargo fetch
+elif [ -f "requirements.txt" ]; then
+    pip install -r requirements.txt
+elif [ -f "go.mod" ]; then
+    go mod download
+else
+    echo "No recognized package manager file found. Skipping install."
+fi
+"""
+
+[tasks.ci]
+depends = ["lint", "test"]


### PR DESCRIPTION
This PR sets up a robust tooling and CI foundation using `mise` and GitHub Actions, establishing the standard pipeline for the repository.

### Assumptions
- The project primarily uses `mise` for task execution to standardize environments.
- Wildcards (`*`) are used for dependencies in `mise.toml` to allow specific subtasks to be added later without modifying the core `[tasks.*]` definitions. `noop` tasks ensure `mise` doesn't fail if no subtasks are present yet.
- The single GitHub Actions workflow is designed to automatically handle codegen updates by opening a PR and stopping further execution if differences are found.
- The pipeline defaults to assuming releases and artifact uploads are necessary for dispatch and tag events.

### Alternatives Not Chosen
- Did not manually install individual linters (e.g., eslint, golangci-lint). `workspaced` handles this automatically.
- Did not attempt to fix any existing code errors or test failures, adhering strictly to the tooling configuration scope.

### How To Pivot
- If the project does not require releases or artifact uploads (e.g., deployed via Vercel/Cloudflare Workers), remove the last two steps in `.github/workflows/autorelease.yml`.

### Next Knobs
- **`mise.toml`**: Add specific `[tasks."test:my-test"]` or `[tasks."codegen:my-codegen"]` to integrate with the wildcard dependencies.
- **`mise.toml` (`install:detect`)**: Add or remove package manager detection logic if the project uses something else (e.g., `bun`).
- **`.github/workflows/autorelease.yml`**: Modify the triggers (e.g., branches or events) for the workflow.

---
*PR created automatically by Jules for task [14467588833173861369](https://jules.google.com/task/14467588833173861369) started by @lucasew*